### PR TITLE
Use shared jonapoul/renovate-config preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,9 +4,8 @@
     "dependencies"
   ],
   "extends": [
-    "config:best-practices"
+    "github>jonapoul/renovate-config"
   ],
-  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       // AGP versions are hardcoded in settings.gradle.kts as well as the version catalog, so
@@ -28,17 +27,6 @@
         "org.jetbrains.kotlin:kotlin-metadata-jvm"
       ],
       "groupName": "kotlin"
-    },
-    {
-      // Check for GitHub Actions updates once a week (Sunday morning),
-      // grouped into a single PR
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "github-actions",
-      "schedule": [
-        "* 0-8 * * 0"
-      ]
     }
   ]
 }

--- a/build-logic/src/main/kotlin/aktual/gradle/ModuleCompose.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ModuleCompose.kt
@@ -30,7 +30,7 @@ class ModuleCompose : ProjectPlugin {
       commonTestDependencies {
         implementation(project(":aktual-test"))
 
-        if (name != ":aktual-test:compose") {
+        if (project.path != ":aktual-test:compose") {
           implementation(project(":aktual-test:compose"))
         }
       }

--- a/build-logic/src/main/kotlin/aktual/gradle/ModuleJvm.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ModuleJvm.kt
@@ -23,6 +23,8 @@ class ModuleJvm : ProjectPlugin {
 
     extensions.configure(Lint::class.java) { lint -> lint.commonConfigure(this@applyTo) }
 
-    dependencies { testLibraries.forEach { lib -> "testImplementation"(lib) } }
+    dependencies {
+      testLibraries.forEach { lib -> "testImplementation"(lib) }
+    }
   }
 }

--- a/build-logic/src/main/kotlin/aktual/gradle/ModuleKotlin.kt
+++ b/build-logic/src/main/kotlin/aktual/gradle/ModuleKotlin.kt
@@ -68,7 +68,9 @@ class ModuleKotlin : ProjectPlugin {
         testLibraries.forEach { lib -> implementation(lib) }
       }
 
-      androidHostTestDependencies { androidTestLibraries.forEach { lib -> implementation(lib) } }
+      androidHostTestDependencies {
+        androidTestLibraries.forEach(::implementation)
+      }
     }
   }
 }


### PR DESCRIPTION
Extends the shared renovate config from jonapoul/renovate-config instead of duplicating config:best-practices, minimumReleaseAge, and the github-actions grouping schedule locally. Project-specific agp/kotlin grouping rules stay as-is.