### PR TITLE
Fix renovate preset reference to jonapoul/renovate-config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     "dependencies"
   ],
   "extends": [
-    "github>jonapoul/renovate-config"
+    "github>jonapoul/renovate-config:default.json5"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
The github> shorthand only resolves a file named default.json, but the shared preset file is default.json5, so the extends entry needs to reference it explicitly.

Closes #1461