### PR TITLE
Don't fail upstream trackers when the existing PR is already up to date

### DIFF
--- a/.github/upstream-migration-tracker/CLAUDE.md
+++ b/.github/upstream-migration-tracker/CLAUDE.md
@@ -4,12 +4,14 @@ Automated system that checks daily for new database migrations in [actualbudget/
 
 ## How It Works
 
-1. The GitHub Action (`.github/workflows/check-upstream-migrations.yml`) runs daily at 08:00 UTC and can be triggered manually.
+1. The GitHub Action (`.github/workflows/check-upstream-changes.yml`) runs daily at 08:00 UTC and can be triggered manually.
 2. `check-migrations.sh` sparse-clones the upstream repo and compares migration files against `last-known-migration.txt`.
 3. If new migrations are found:
    - Updates `last-known-migration.txt` to the newest migration.
-   - Creates a PR on branch `auto/upstream-migrations` listing the new migrations (label: `db-migration`).
-   - If a PR already exists, pushes to the same branch and appends the new migrations to the PR body.
+   - Creates a PR on branch `auto/upstream-migrations` listing the new migrations (label: `upstream-changes`).
+   - If a PR already exists, the new migrations are recomputed against the tracker on that branch (the
+     one on `main` lags behind while the PR is open), then pushed and appended to the PR body. If the
+     branch already covers everything upstream, the workflow exits cleanly.
 4. If no new migrations are found, the workflow exits cleanly with no side effects.
 
 ## Files

--- a/.github/upstream-migration-tracker/check-migrations.sh
+++ b/.github/upstream-migration-tracker/check-migrations.sh
@@ -40,25 +40,34 @@ git -C "$tmp_dir" sparse-checkout set "$MIGRATIONS_PATH"
 
 mapfile -t all_migrations < <(find "$tmp_dir/$MIGRATIONS_PATH" -maxdepth 1 -type f -printf '%f\n' | sort)
 
-new_migrations=()
-found_last=false
-for migration in "${all_migrations[@]}"; do
-  if [[ "$found_last" == true ]]; then
-    new_migrations+=("$migration")
-  elif [[ "$migration" == "$last_known" ]]; then
-    found_last=true
-  fi
-done
+# Populates the new_migrations array with everything upstream has after the given migration
+compute_new_migrations() {
+  local baseline="$1"
+  local found_last=false
+  local migration
 
-if [[ "$found_last" == false ]]; then
-  echo "WARNING: Last known migration '$last_known' was not found in upstream."
-  echo "This may mean it was renamed or removed. Listing all migrations after it alphabetically."
+  new_migrations=()
   for migration in "${all_migrations[@]}"; do
-    if [[ "$migration" > "$last_known" ]]; then
+    if [[ "$found_last" == true ]]; then
       new_migrations+=("$migration")
+    elif [[ "$migration" == "$baseline" ]]; then
+      found_last=true
     fi
   done
-fi
+
+  if [[ "$found_last" == false ]]; then
+    echo "WARNING: Last known migration '$baseline' was not found in upstream."
+    echo "This may mean it was renamed or removed. Listing all migrations after it alphabetically."
+    for migration in "${all_migrations[@]}"; do
+      if [[ "$migration" > "$baseline" ]]; then
+        new_migrations+=("$migration")
+      fi
+    done
+  fi
+}
+
+new_migrations=()
+compute_new_migrations "$last_known"
 
 if [[ ${#new_migrations[@]} -eq 0 ]]; then
   echo "No new migrations found."
@@ -112,9 +121,6 @@ if [[ -z "$GITHUB_REPOSITORY" ]]; then
   exit 1
 fi
 
-# Update the tracker file to the newest migration
-echo "$newest_migration" > "$TRACKER_FILE"
-
 # Set up git for committing
 git config user.name "Jon Poulton"
 git config user.email "jpoulton@pm.me"
@@ -137,6 +143,23 @@ if [[ -n "$existing_pr" ]]; then
   # Check out the existing PR branch and update the tracker file
   git fetch origin "$PR_BRANCH"
   git checkout "$PR_BRANCH"
+
+  # The tracker on main lags behind while the PR is open, so recompute against the branch's own
+  # tracker. Otherwise every run re-reports the same migrations and tries to make an empty commit.
+  branch_last_known="$(tr -d '[:space:]' < "$TRACKER_FILE")"
+  compute_new_migrations "$branch_last_known"
+
+  if [[ ${#new_migrations[@]} -eq 0 ]]; then
+    echo "PR #$pr_number already covers every upstream migration. Nothing to do."
+    exit 0
+  fi
+
+  echo "Found ${#new_migrations[@]} migration(s) not yet listed in PR #$pr_number:"
+  printf '  %s\n' "${new_migrations[@]}"
+
+  new_rows="$(build_table_rows "${new_migrations[@]}")"
+  newest_migration="${new_migrations[${#new_migrations[@]}-1]}"
+
   echo "$newest_migration" > "$TRACKER_FILE"
   git add "$TRACKER_FILE"
   git commit -m "Update last known upstream migration to $newest_migration"
@@ -189,6 +212,7 @@ EOF
 
   # Create branch, commit, and push
   git checkout -B "$PR_BRANCH"
+  echo "$newest_migration" > "$TRACKER_FILE"
   git add "$TRACKER_FILE"
   git commit -m "Update last known upstream migration to $newest_migration"
   git push -u origin "$PR_BRANCH"

--- a/.github/upstream-theme-tracker/check-theme-attributes.sh
+++ b/.github/upstream-theme-tracker/check-theme-attributes.sh
@@ -124,9 +124,6 @@ if [[ -z "$GITHUB_REPOSITORY" ]]; then
   exit 1
 fi
 
-# Update the tracker file to the current upstream state
-cp "$tmp_dir/all_attrs.txt" "$TRACKER_FILE"
-
 # Set up git for committing
 git config user.name "Jon Poulton"
 git config user.email "jpoulton@pm.me"
@@ -189,6 +186,32 @@ if [[ -n "$existing_pr" ]]; then
   # Check out the existing PR branch and update the tracker file
   git fetch origin "$PR_BRANCH"
   git checkout "$PR_BRANCH"
+
+  # The tracker on main lags behind while the PR is open, so recompute against the branch's own
+  # tracker. Otherwise every run re-reports the same attributes and tries to make an empty commit.
+  branch_attrs="$(sort < "$TRACKER_FILE")"
+  new_attrs="$(comm -23 "$tmp_dir/all_attrs.txt" <(echo "$branch_attrs"))"
+  removed_attrs="$(comm -13 "$tmp_dir/all_attrs.txt" <(echo "$branch_attrs"))"
+
+  if [[ -z "$new_attrs" && -z "$removed_attrs" ]]; then
+    echo "PR #$pr_number already covers every upstream theme attribute. Nothing to do."
+    exit 0
+  fi
+
+  new_rows=""
+  if [[ -n "$new_attrs" ]]; then
+    echo "$(echo "$new_attrs" | wc -l) added attribute(s) not yet listed in PR #$pr_number:"
+    echo "  ${new_attrs//$'\n'/$'\n'  }"
+    new_rows="$(build_new_rows "$new_attrs")"
+  fi
+
+  removed_rows=""
+  if [[ -n "$removed_attrs" ]]; then
+    echo "$(echo "$removed_attrs" | wc -l) removed attribute(s) not yet listed in PR #$pr_number:"
+    echo "  ${removed_attrs//$'\n'/$'\n'  }"
+    removed_rows="$(build_removed_rows "$removed_attrs")"
+  fi
+
   cp "$tmp_dir/all_attrs.txt" "$TRACKER_FILE"
   git add "$TRACKER_FILE"
   git commit -m "Update known upstream theme attributes"
@@ -232,6 +255,7 @@ else
 
   # Create branch, commit, and push
   git checkout -B "$PR_BRANCH"
+  cp "$tmp_dir/all_attrs.txt" "$TRACKER_FILE"
   git add "$TRACKER_FILE"
   git commit -m "Update known upstream theme attributes"
   git push -u origin "$PR_BRANCH"


### PR DESCRIPTION
The daily workflow checks out `main`, whose tracker files stay stale while an auto PR is open. So each subsequent run re-detected the same migrations/attributes and failed: first on `git checkout` (tracker written before switching branches), and otherwise on an empty `git commit`.

Now the tracker is only written once we're on the right branch, and new entries are recomputed against that branch's own tracker. If the open PR already covers everything upstream, the run exits cleanly. Creating a new PR is unchanged.

Also stops duplicate rows being appended to the PR body, and fixes the workflow filename and label in the tracker CLAUDE.md.