### PR TITLE
Update haze to 2.0.0-beta02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ detekt-testJunit = { module = "dev.detekt:detekt-test-junit", version.ref = "det
 detekt-testUtils = { module = "dev.detekt:detekt-test-utils", version.ref = "detekt" }
 detektCompose = { module = "io.nlopez.compose.rules:detekt", version = "0.6.6" }
 detektGradle = { module = "dev.jonpoulton.blueprint:detekt-rules", version.ref = "blueprint" }
-haze = { module = "dev.chrisbanes.haze:haze-blur", version = "2.0.0-SNAPSHOT" }
+haze = { module = "dev.chrisbanes.haze:haze-blur", version = "2.0.0-beta02" }
 junit = { module = "junit:junit", version = "4.13.2" }
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.3" }
 kermit = { module = "co.touchlab:kermit", version = "2.1.0" }


### PR DESCRIPTION
Fix [CI failures on main](https://github.com/jonapoul/aktual/actions/runs/34020379385/job/101451732757):

```
FAILURE: Build failed with an exception.
gradle/actions: Writing build results to /home/runner/work/_temp/.gradle-actions/build-results/__run-1788681277564.json

7 actionable tasks: 5 executed, 2 from cache
* What went wrong:
Could not determine the dependencies of task ':aktual-about:ui:desktopTest'.
> Could not resolve all dependencies for configuration ':aktual-about:ui:desktopTestRuntimeClasspath'.
   > Could not find dev.chrisbanes.haze:haze-blur:2.0.0-SNAPSHOT.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/dev/chrisbanes/haze/haze-blur/2.0.0-SNAPSHOT/maven-metadata.xml
       - https://plugins.gradle.org/m2/dev/chrisbanes/haze/haze-blur/2.0.0-SNAPSHOT/haze-blur-2.0.0-SNAPSHOT.pom
       - https://central.sonatype.com/repository/maven-snapshots/dev/chrisbanes/haze/haze-blur/2.0.0-SNAPSHOT/maven-metadata.xml
       - https://central.sonatype.com/repository/maven-snapshots/dev/chrisbanes/haze/haze-blur/2.0.0-SNAPSHOT/haze-blur-2.0.0-SNAPSHOT.pom
     Required by:
         project ':aktual-about:ui' > project ':aktual-core:ui'

* Try:
Configuration cache entry stored.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org/.
```